### PR TITLE
LAGJH-1063 Add Databases CRUD

### DIFF
--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Controller for Databases
+class DatabasesController < ApplicationController
+  before_action :set_database, only: %i[show edit update destroy]
+  before_action :require_login
+
+  # GET /databases or /databases.json
+  def index
+    @databases = Database.all
+  end
+
+  # GET /databases/1 or /databases/1.json
+  def show; end
+
+  # GET /databases/new
+  def new
+    @database = Database.new
+  end
+
+  # GET /databases/1/edit
+  def edit; end
+
+  # POST /databases or /databases.json
+  def create
+    @database = Database.new(database_params)
+
+    respond_to do |format|
+      if @database.save
+        format.html { redirect_to database_url(@database), notice: 'Database was successfully created.' }
+        format.json { render :show, status: :created, location: @database }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @database.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /databases/1 or /databases/1.json
+  def update
+    respond_to do |format|
+      if @database.update(database_params)
+        format.html { redirect_to database_url(@database), notice: 'Database was successfully updated.' }
+        format.json { render :show, status: :ok, location: @database }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @database.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /databases/1 or /databases/1.json
+  def destroy
+    @database.destroy
+
+    respond_to do |format|
+      format.html { redirect_to databases_url, notice: 'Database was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_database
+    @database = Database.find(params[:id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def database_params
+    params.require(:database).permit(:vendor_id, :jhu_id, :name, :url, :enable_proxy, :description, :internal_note)
+  end
+
+  # Require login
+  def require_login
+    redirect_to new_user_session_path if current_user.blank?
+  end
+end

--- a/app/helpers/databases_helper.rb
+++ b/app/helpers/databases_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Helpers for databases
+module DatabasesHelper
+end

--- a/app/models/database.rb
+++ b/app/models/database.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# The Database model. Database in this case is an acaedmic resource like EBSCO Academic Search Ultimate
+# not a relational database.
+class Database < ApplicationRecord
+  belongs_to :vendor
+  validates :url, uniqueness: true, presence: true
+  validates :name, uniqueness: true, presence: true
+  validates :jhu_id, uniqueness: true, presence: true
+end

--- a/app/views/databases/_database.html.erb
+++ b/app/views/databases/_database.html.erb
@@ -1,0 +1,37 @@
+<div id="<%= dom_id database %>">
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Vendor:</strong>
+    <%= Vendor.find(database.vendor_id).brand_name %>
+  </p>
+
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Name:</strong>
+    <%= database.name %>
+  </p>
+
+  <p class="my-5">
+    <strong class="block font-medium mb-1">URL:</strong>
+    <%= link_to(database.url) %>
+  </p>
+
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Enable proxy:</strong>
+    <%= database.enable_proxy %>
+  </p>
+
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Description:</strong>
+    <%= database.description %>
+  </p>
+
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Internal note:</strong>
+    <%= database.internal_note %>
+  </p>
+
+  <% if action_name != "show" %>
+    <%= link_to "Show this database", database, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to 'Edit this database', edit_database_path(database), class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
+    <hr class="mt-6">
+  <% end %>
+</div>

--- a/app/views/databases/_database.json.jbuilder
+++ b/app/views/databases/_database.json.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.extract! database, :id, :vendor_id, :name, :url, :enable_proxy, :description, :internal_note, :created_at,
+              :updated_at
+json.url database_url(database, format: :json)

--- a/app/views/databases/_form.html.erb
+++ b/app/views/databases/_form.html.erb
@@ -1,0 +1,10 @@
+<%= simple_form_for @database do |f| %>
+  <%= f.association :vendor, label_method: :brand_name, value_method: :id, include_blank: false,  label: 'Vendor' %>
+  <%= f.input :jhu_id, label: 'JHU ID' %>
+  <%= f.input :name, label: 'Name' %>
+  <%= f.input :url, label: 'URL' %>
+  <%= f.input :enable_proxy, label: 'Enable Proxy?' %>
+  <%= f.input :description, label: 'Description' %>
+  <%= f.input :internal_note, label: 'Internal Note' %>
+  <%= f.button :submit %>
+<% end %>

--- a/app/views/databases/edit.html.erb
+++ b/app/views/databases/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">Editing database</h1>
+
+  <%= render "form", database: @database %>
+
+  <%= link_to "Show this database", @database, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%= link_to "Back to databases", databases_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/app/views/databases/index.html.erb
+++ b/app/views/databases/index.html.erb
@@ -1,0 +1,14 @@
+<div class="w-full">
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+  <% end %>
+
+  <div class="flex justify-between items-center">
+    <h1 class="font-bold text-4xl">Databases</h1>
+    <%= link_to 'New database', new_database_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
+  </div>
+
+  <div id="databases" class="min-w-full">
+    <%= render @databases %>
+  </div>
+</div>

--- a/app/views/databases/index.json.jbuilder
+++ b/app/views/databases/index.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @databases, partial: 'databases/database', as: :database

--- a/app/views/databases/new.html.erb
+++ b/app/views/databases/new.html.erb
@@ -1,0 +1,7 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">New database</h1>
+
+  <%= render "form", database: @database %>
+
+  <%= link_to 'Back to databases', databases_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/app/views/databases/show.html.erb
+++ b/app/views/databases/show.html.erb
@@ -1,0 +1,15 @@
+<div class="mx-auto md:w-2/3 w-full flex">
+  <div class="mx-auto">
+    <% if notice.present? %>
+      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+    <% end %>
+
+    <%= render @database %>
+
+    <%= link_to 'Edit this database', edit_database_path(@database), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <div class="inline-block ml-2">
+      <%= button_to 'Destroy this database', database_path(@database), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+    </div>
+    <%= link_to 'Back to databases', databases_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  </div>
+</div>

--- a/app/views/databases/show.json.jbuilder
+++ b/app/views/databases/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! 'databases/database', database: @database

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,1 +1,4 @@
-<div class="max-w-7xl mx-auto"><h1>hummingbird<h1></div>
+<nav class="ml-20">
+<%= link_to 'Vendors', vendors_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+<%= link_to 'Databases', databases_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  resources :databases
   resources :vendors
   devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20220531182118_create_databases.rb
+++ b/db/migrate/20220531182118_create_databases.rb
@@ -1,0 +1,14 @@
+class CreateDatabases < ActiveRecord::Migration[7.0]
+  def change
+    create_table :databases do |t|
+      t.references :vendor, null: false, foreign_key: true
+      t.text :name
+      t.text :url
+      t.boolean :enable_proxy
+      t.text :description
+      t.text :internal_note
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220531192422_add_unique_url_index_to_databases.rb
+++ b/db/migrate/20220531192422_add_unique_url_index_to_databases.rb
@@ -1,0 +1,5 @@
+class AddUniqueUrlIndexToDatabases < ActiveRecord::Migration[7.0]
+  def change
+    add_index :databases, :url, unique: true
+  end
+end

--- a/db/migrate/20220531192636_add_unique_name_index_to_databases.rb
+++ b/db/migrate/20220531192636_add_unique_name_index_to_databases.rb
@@ -1,0 +1,5 @@
+class AddUniqueNameIndexToDatabases < ActiveRecord::Migration[7.0]
+  def change
+    add_index :databases, :name, unique: true
+  end
+end

--- a/db/migrate/20220531201129_add_jhu_id_to_databases.rb
+++ b/db/migrate/20220531201129_add_jhu_id_to_databases.rb
@@ -1,0 +1,6 @@
+class AddJhuIdToDatabases < ActiveRecord::Migration[7.0]
+  def change
+    add_column :databases, :jhu_id, :string
+    add_index :databases, :jhu_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_27_145759) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_31_201129) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "databases", force: :cascade do |t|
+    t.bigint "vendor_id", null: false
+    t.text "name"
+    t.text "url"
+    t.boolean "enable_proxy"
+    t.text "description"
+    t.text "internal_note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "jhu_id"
+    t.index ["jhu_id"], name: "index_databases_on_jhu_id", unique: true
+    t.index ["name"], name: "index_databases_on_name", unique: true
+    t.index ["url"], name: "index_databases_on_url", unique: true
+    t.index ["vendor_id"], name: "index_databases_on_vendor_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -33,4 +49,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_27_145759) do
     t.index ["brand_name"], name: "index_vendors_on_brand_name", unique: true
   end
 
+  add_foreign_key "databases", "vendors"
 end

--- a/spec/factories/databases.rb
+++ b/spec/factories/databases.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :database do
+    jhu_id { "JHU#{FFaker::Lorem.characters(5)}" }
+    vendor { FactoryBot.create(:vendor) }
+    name { FFaker::Company.name }
+    url { FFaker::Internet.http_url }
+    enable_proxy { false }
+    description { FFaker::Lorem.paragraph }
+    internal_note { FFaker::Lorem.paragraph }
+  end
+end

--- a/spec/requests/databases_spec.rb
+++ b/spec/requests/databases_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '/databases', type: :request do
+  let(:vendor) { FactoryBot.create(:vendor) }
+  let(:database) { FactoryBot.create(:database) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:required_attributes) do
+    { name: FFaker::Company.name,
+      jhu_id: "JHU#{FFaker::Lorem.characters(5)}",
+      url: FFaker::Internet.http_url,
+      vendor_id: vendor.id }
+  end
+
+  before do
+    sign_in user
+    vendor.save!
+    database.save!
+  end
+
+  describe 'GET /index' do
+    it 'renders a successful response' do
+      get databases_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /show' do
+    it 'renders a successful response' do
+      get database_url(database)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /new' do
+    it 'renders a successful response' do
+      get new_database_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /edit' do
+    it 'renders a successful response' do
+      get edit_database_url(database)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters' do
+      it 'creates a new Database' do
+        expect do
+          post databases_url, params: { database: required_attributes }
+        end.to change(Database, :count).by(1)
+      end
+
+      it 'redirects to the created database' do
+        post databases_url, params: { database: required_attributes }
+        expect(response).to redirect_to(database_url(Database.last))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new Database' do
+        allow_any_instance_of(Database).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+
+        put database_url(database), params: { database: { id: '1' } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders a response with 422 status (i.e. to display the 'new' template)" do
+        allow_any_instance_of(Database).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+        post databases_url, params: { database: { id: '1' } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'PATCH /update' do
+    context 'with valid parameters' do
+      it 'updates the requested database' do
+        patch database_url(database), params: { database: database.attributes }
+        database.reload
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'redirects to the database' do
+        patch database_url(database), params: { database: database.attributes }
+        database.reload
+        expect(response).to redirect_to(database_url(database))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+        allow_any_instance_of(Database).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+
+        patch database_url(database), params: { database: { id: '1' } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the requested database' do
+      expect do
+        delete database_url(database)
+      end.to change(Database, :count).by(-1)
+    end
+
+    it 'redirects to the databases list' do
+      delete database_url(database)
+      expect(response).to redirect_to(databases_url)
+    end
+  end
+end

--- a/spec/system/databases_spec.rb
+++ b/spec/system/databases_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Database CRUD Operations', type: :system do
+  let(:user) { FactoryBot.create(:user) }
+  let(:vendor) { FactoryBot.create(:vendor) }
+  let(:database) { FactoryBot.create(:vendor) }
+
+  before do
+    driven_by(:selenium_chrome_headless)
+    visit root_path
+
+    vendor.save!
+
+    click_link 'Log in'
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+    click_button 'Log in'
+  end
+
+  it 'can create a database' do
+    visit '/databases'
+
+    click_on 'New database'
+    fill_in 'JHU ID', with: "JHU#{FFaker::Lorem.characters(5)}"
+    fill_in 'Name', with: FFaker::Company.name
+    fill_in 'URL', with: FFaker::Internet.http_url
+    check('Enable Proxy?', allow_label_click: true)
+    fill_in 'Description', with: FFaker::Lorem.paragraph
+    fill_in 'Internal Note', with: FFaker::Lorem.paragraph
+
+    click_on 'Create Database'
+
+    expect(page).to have_content('Database was successfully created.')
+  end
+
+  it 'can update a database' do
+    visit '/databases'
+
+    click_on 'New database'
+    fill_in 'JHU ID', with: "JHU#{FFaker::Lorem.characters(5)}"
+    fill_in 'Name', with: FFaker::Company.name
+    fill_in 'URL', with: FFaker::Internet.http_url
+    check('Enable Proxy?', allow_label_click: true)
+    fill_in 'Description', with: FFaker::Lorem.paragraph
+    fill_in 'Internal Note', with: FFaker::Lorem.paragraph
+
+    click_on 'Create Database'
+
+    visit '/databases'
+    click_on 'Edit this database'
+    fill_in 'Name', with: FFaker::Company.name
+    click_on 'Update Database'
+
+    expect(page).to have_content('Database was successfully updated.')
+  end
+
+  it 'can delete database' do
+    visit '/databases'
+    click_on 'New database'
+    fill_in 'JHU ID', with: "JHU#{FFaker::Lorem.characters(5)}"
+    fill_in 'Name', with: FFaker::Company.name
+    fill_in 'URL', with: FFaker::Internet.http_url
+    check('Enable Proxy?', allow_label_click: true)
+    fill_in 'Description', with: FFaker::Lorem.paragraph
+    fill_in 'Internal Note', with: FFaker::Lorem.paragraph
+
+    click_on 'Create Database'
+
+    visit '/databases'
+
+    click_on 'Show this database'
+    click_on 'Destroy this database'
+
+    expect(page).to have_content('Database was successfully destroyed.')
+  end
+end

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe 'HomePages', type: :system do
 
   it 'is accessible' do
     visit root_path
-    expect(page).to have_content('hummingbird')
+    expect(page).to have_content('Hummingbird')
   end
 end


### PR DESCRIPTION
This adds CRUD for Database records.

This PR has additional database migrations. After
checking out this branch you'll need to run
`docker-compose run --rm hummingbird bundle exec rake db:migrate`
to update the database.

You can test the functionality by logging in and visiting
`/databases/`. A database requires a vendor
assocation so you will need to create a vendor
before creating a database.