### PR TITLE
LAGJH-1047 CRUD for headings.

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Controller for categories
+class CategoriesController < ApplicationController
+  before_action :set_category, only: %i[show edit update destroy]
+  before_action :require_login
+
+  # GET /categories or /categories.json
+  def index
+    @categories = Category.all
+  end
+
+  # GET /categories/1 or /categories/1.json
+  def show; end
+
+  # GET /categories/new
+  def new
+    @category = Category.new
+  end
+
+  # GET /categories/1/edit
+  def edit; end
+
+  # POST /categories or /categories.json
+  def create
+    @category = Category.new(category_params)
+
+    respond_to do |format|
+      if @category.save
+        format.html { redirect_to category_url(@category), notice: 'Category was successfully created.' }
+        format.json { render :show, status: :created, location: @category }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @category.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /categories/1 or /categories/1.json
+  def update
+    respond_to do |format|
+      if @category.update(category_params)
+        format.html { redirect_to category_url(@category), notice: 'Category was successfully updated.' }
+        format.json { render :show, status: :ok, location: @category }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @category.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /categories/1 or /categories/1.json
+  def destroy
+    @category.destroy
+
+    respond_to do |format|
+      format.html { redirect_to categories_url, notice: 'Category was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_category
+    @category = Category.find(params[:id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def category_params
+    params.require(:category).permit(:label)
+  end
+
+  # Require login
+  def require_login
+    redirect_to new_user_session_path if current_user.blank?
+  end
+end

--- a/app/controllers/database_headings_controller.rb
+++ b/app/controllers/database_headings_controller.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Controller for database headings
+class DatabaseHeadingsController < ApplicationController
+  before_action :set_database_heading, only: %i[show edit update destroy]
+  before_action :require_login
+
+  # GET /database_headings or /database_headings.json
+  def index
+    @database_headings = DatabaseHeading.all
+  end
+
+  # GET /database_headings/1 or /database_headings/1.json
+  def show; end
+
+  # GET /database_headings/new
+  def new
+    @database_heading = DatabaseHeading.new
+  end
+
+  # GET /database_headings/1/edit
+  def edit; end
+
+  # POST /database_headings or /database_headings.json
+  def create # rubocop:disable Metrics/MethodLength
+    @database_heading = DatabaseHeading.new(database_heading_params)
+
+    respond_to do |format|
+      if @database_heading.save
+        format.html do
+          redirect_to database_heading_url(@database_heading), notice: 'Database heading was successfully created.'
+        end
+        format.json { render :show, status: :created, location: @database_heading }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @database_heading.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /database_headings/1 or /database_headings/1.json
+  def update # rubocop:disable Metrics/MethodLength
+    respond_to do |format|
+      if @database_heading.update(database_heading_params)
+        format.html do
+          redirect_to database_heading_url(@database_heading), notice: 'Database heading was successfully updated.'
+        end
+        format.json { render :show, status: :ok, location: @database_heading }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @database_heading.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /database_headings/1 or /database_headings/1.json
+  def destroy
+    @database_heading.destroy
+
+    respond_to do |format|
+      format.html { redirect_to database_headings_url, notice: 'Database heading was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_database_heading
+    @database_heading = DatabaseHeading.find(params[:id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def database_heading_params
+    params.require(:database_heading).permit(:database_id, :heading_id)
+  end
+
+  # Require login
+  def require_login
+    redirect_to new_user_session_path if current_user.blank?
+  end
+end

--- a/app/controllers/headings_controller.rb
+++ b/app/controllers/headings_controller.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Controller for headings
+class HeadingsController < ApplicationController
+  before_action :set_heading, only: %i[show edit update destroy]
+  before_action :require_login
+
+  # GET /headings or /headings.json
+  def index
+    @headings = Heading.all
+  end
+
+  # GET /headings/1 or /headings/1.json
+  def show; end
+
+  # GET /headings/new
+  def new
+    @heading = Heading.new
+  end
+
+  # GET /headings/1/edit
+  def edit; end
+
+  # POST /headings or /headings.json
+  def create
+    @heading = Heading.new(heading_params)
+
+    respond_to do |format|
+      if @heading.save
+        format.html { redirect_to heading_url(@heading), notice: 'Heading was successfully created.' }
+        format.json { render :show, status: :created, location: @heading }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @heading.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /headings/1 or /headings/1.json
+  def update
+    respond_to do |format|
+      if @heading.update(heading_params)
+        format.html { redirect_to heading_url(@heading), notice: 'Heading was successfully updated.' }
+        format.json { render :show, status: :ok, location: @heading }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @heading.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /headings/1 or /headings/1.json
+  def destroy
+    @heading.destroy
+
+    respond_to do |format|
+      format.html { redirect_to headings_url, notice: 'Heading was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_heading
+    @heading = Heading.find(params[:id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def heading_params
+    params.require(:heading).permit(:category_id, :subcategory_id)
+  end
+
+  # Require login
+  def require_login
+    redirect_to new_user_session_path if current_user.blank?
+  end
+end

--- a/app/controllers/subcategories_controller.rb
+++ b/app/controllers/subcategories_controller.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Controller for subcategories
+class SubcategoriesController < ApplicationController
+  before_action :set_subcategory, only: %i[show edit update destroy]
+  before_action :require_login
+
+  # GET /subcategories or /subcategories.json
+  def index
+    @subcategories = Subcategory.all
+  end
+
+  # GET /subcategories/1 or /subcategories/1.json
+  def show; end
+
+  # GET /subcategories/new
+  def new
+    @subcategory = Subcategory.new
+  end
+
+  # GET /subcategories/1/edit
+  def edit; end
+
+  # POST /subcategories or /subcategories.json
+  def create
+    @subcategory = Subcategory.new(subcategory_params)
+
+    respond_to do |format|
+      if @subcategory.save
+        format.html { redirect_to subcategory_url(@subcategory), notice: 'Subcategory was successfully created.' }
+        format.json { render :show, status: :created, location: @subcategory }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @subcategory.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /subcategories/1 or /subcategories/1.json
+  def update
+    respond_to do |format|
+      if @subcategory.update(subcategory_params)
+        format.html { redirect_to subcategory_url(@subcategory), notice: 'Subcategory was successfully updated.' }
+        format.json { render :show, status: :ok, location: @subcategory }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @subcategory.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /subcategories/1 or /subcategories/1.json
+  def destroy
+    @subcategory.destroy
+
+    respond_to do |format|
+      format.html { redirect_to subcategories_url, notice: 'Subcategory was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_subcategory
+    @subcategory = Subcategory.find(params[:id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def subcategory_params
+    params.require(:subcategory).permit(:label)
+  end
+
+  # Require login
+  def require_login
+    redirect_to new_user_session_path if current_user.blank?
+  end
+end

--- a/app/helpers/databases_helper.rb
+++ b/app/helpers/databases_helper.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-# Helpers for databases
-module DatabasesHelper
-end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-# Helpers specfic to the home page
-module HomeHelper
-end

--- a/app/helpers/vendors_helper.rb
+++ b/app/helpers/vendors_helper.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-# Helpers for vendors
-module VendorsHelper
-end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Category < ApplicationRecord
+end

--- a/app/models/database.rb
+++ b/app/models/database.rb
@@ -7,4 +7,7 @@ class Database < ApplicationRecord
   validates :url, uniqueness: true, presence: true
   validates :name, uniqueness: true, presence: true
   validates :jhu_id, uniqueness: true, presence: true
+
+  has_many :database_headings, dependent: :destroy
+  has_many :headings, through: :database_headings
 end

--- a/app/models/database_heading.rb
+++ b/app/models/database_heading.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class DatabaseHeading < ApplicationRecord
+  belongs_to :database
+  belongs_to :heading
+end

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# A heading combines a category with a subcategory.
+class Heading < ApplicationRecord
+  belongs_to :category
+  belongs_to :subcategory
+
+  def label
+    "#{category.label} – #{subcategory.label}"
+  end
+end

--- a/app/models/subcategory.rb
+++ b/app/models/subcategory.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Subcategory < ApplicationRecord
+end

--- a/app/views/categories/_category.html.erb
+++ b/app/views/categories/_category.html.erb
@@ -1,0 +1,12 @@
+<div id="<%= dom_id category %>">
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Label:</strong>
+    <%= category.label %>
+  </p>
+
+  <% if action_name != "show" %>
+    <%= link_to "Show this category", category, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to 'Edit this category', edit_category_path(category), class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
+    <hr class="mt-6">
+  <% end %>
+</div>

--- a/app/views/categories/_category.json.jbuilder
+++ b/app/views/categories/_category.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.extract! category, :id, :label, :created_at, :updated_at
+json.url category_url(category, format: :json)

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: category, class: "contents") do |form| %>
+  <% if category.errors.any? %>
+    <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
+      <h2><%= pluralize(category.errors.count, "error") %> prohibited this category from being saved:</h2>
+
+      <ul>
+        <% category.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="my-5">
+    <%= form.label :label %>
+    <%= form.text_field :label, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+  </div>
+
+  <div class="inline">
+    <%= form.submit class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+  </div>
+<% end %>

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">Editing category</h1>
+
+  <%= render "form", category: @category %>
+
+  <%= link_to "Show this category", @category, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%= link_to "Back to categories", categories_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,0 +1,14 @@
+<div class="w-full">
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+  <% end %>
+
+  <div class="flex justify-between items-center">
+    <h1 class="font-bold text-4xl">Categories</h1>
+    <%= link_to 'New category', new_category_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
+  </div>
+
+  <div id="categories" class="min-w-full">
+    <%= render @categories %>
+  </div>
+</div>

--- a/app/views/categories/index.json.jbuilder
+++ b/app/views/categories/index.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @categories, partial: 'categories/category', as: :category

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,0 +1,7 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">New category</h1>
+
+  <%= render "form", category: @category %>
+
+  <%= link_to 'Back to categories', categories_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,0 +1,15 @@
+<div class="mx-auto md:w-2/3 w-full flex">
+  <div class="mx-auto">
+    <% if notice.present? %>
+      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+    <% end %>
+
+    <%= render @category %>
+
+    <%= link_to 'Edit this category', edit_category_path(@category), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <div class="inline-block ml-2">
+      <%= button_to 'Destroy this category', category_path(@category), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+    </div>
+    <%= link_to 'Back to categories', categories_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  </div>
+</div>

--- a/app/views/categories/show.json.jbuilder
+++ b/app/views/categories/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! 'categories/category', category: @category

--- a/app/views/database_headings/_database_heading.html.erb
+++ b/app/views/database_headings/_database_heading.html.erb
@@ -1,0 +1,17 @@
+<div id="<%= dom_id database_heading %>">
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Database:</strong>
+    <%= Database.find(database_heading.database_id).name %>
+  </p>
+
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Heading:</strong>
+    <%= Heading.find(database_heading.heading_id).label %>
+  </p>
+
+  <% if action_name != "show" %>
+    <%= link_to "Show this database heading", database_heading, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to 'Edit this database heading', edit_database_heading_path(database_heading), class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
+    <hr class="mt-6">
+  <% end %>
+</div>

--- a/app/views/database_headings/_database_heading.json.jbuilder
+++ b/app/views/database_headings/_database_heading.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.extract! database_heading, :id, :database_id, :heading_id, :created_at, :updated_at
+json.url database_heading_url(database_heading, format: :json)

--- a/app/views/database_headings/_form.html.erb
+++ b/app/views/database_headings/_form.html.erb
@@ -1,0 +1,6 @@
+<%= simple_form_for @database_heading do |f| %>
+  <%= f.association :database, label_method: :name, value_method: :id, include_blank: false,  label: 'Database' %>
+  <%= f.association :heading, label_method: :label, value_method: :id, include_blank: false,  label: 'Heading' %>
+
+  <%= f.button :submit %>
+<% end %>

--- a/app/views/database_headings/edit.html.erb
+++ b/app/views/database_headings/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">Editing database heading</h1>
+
+  <%= render "form", database_heading: @database_heading %>
+
+  <%= link_to "Show this database heading", @database_heading, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%= link_to "Back to database headings", database_headings_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/app/views/database_headings/index.html.erb
+++ b/app/views/database_headings/index.html.erb
@@ -1,0 +1,14 @@
+<div class="w-full">
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+  <% end %>
+
+  <div class="flex justify-between items-center">
+    <h1 class="font-bold text-4xl">Database headings</h1>
+    <%= link_to 'New database heading', new_database_heading_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
+  </div>
+
+  <div id="database_headings" class="min-w-full">
+    <%= render @database_headings %>
+  </div>
+</div>

--- a/app/views/database_headings/index.json.jbuilder
+++ b/app/views/database_headings/index.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @database_headings, partial: 'database_headings/database_heading', as: :database_heading

--- a/app/views/database_headings/new.html.erb
+++ b/app/views/database_headings/new.html.erb
@@ -1,0 +1,7 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">New database heading</h1>
+
+  <%= render "form", database_heading: @database_heading %>
+
+  <%= link_to 'Back to database headings', database_headings_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/app/views/database_headings/show.html.erb
+++ b/app/views/database_headings/show.html.erb
@@ -1,0 +1,15 @@
+<div class="mx-auto md:w-2/3 w-full flex">
+  <div class="mx-auto">
+    <% if notice.present? %>
+      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+    <% end %>
+
+    <%= render @database_heading %>
+
+    <%= link_to 'Edit this database_heading', edit_database_heading_path(@database_heading), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <div class="inline-block ml-2">
+      <%= button_to 'Destroy this database_heading', database_heading_path(@database_heading), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+    </div>
+    <%= link_to 'Back to database_headings', database_headings_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  </div>
+</div>

--- a/app/views/database_headings/show.json.jbuilder
+++ b/app/views/database_headings/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! 'database_headings/database_heading', database_heading: @database_heading

--- a/app/views/databases/_database.html.erb
+++ b/app/views/databases/_database.html.erb
@@ -11,7 +11,7 @@
 
   <p class="my-5">
     <strong class="block font-medium mb-1">URL:</strong>
-    <%= link_to(database.url) %>
+    <%= link_to(database.url, database.url) %>
   </p>
 
   <p class="my-5">
@@ -27,6 +27,11 @@
   <p class="my-5">
     <strong class="block font-medium mb-1">Internal note:</strong>
     <%= database.internal_note %>
+  </p>
+
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Headings:</strong>
+    <%= database.headings.map { |h| h.label }.join(',') %>
   </p>
 
   <% if action_name != "show" %>

--- a/app/views/headings/_form.html.erb
+++ b/app/views/headings/_form.html.erb
@@ -1,0 +1,6 @@
+<%= simple_form_for @heading do |f| %>
+  <%= f.association :category, label_method: :label, value_method: :id, include_blank: false,  label: 'Category' %>
+  <%= f.association :subcategory, label_method: :label, value_method: :id, include_blank: false,  label: 'Subcategory ' %>
+
+  <%= f.button :submit %>
+<% end %>

--- a/app/views/headings/_heading.html.erb
+++ b/app/views/headings/_heading.html.erb
@@ -1,0 +1,12 @@
+<div id="<%= dom_id heading %>">
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Label:</strong>
+    <%= heading.label %>
+  </p>
+
+  <% if action_name != "show" %>
+    <%= link_to "Show this heading", heading, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to 'Edit this heading', edit_heading_path(heading), class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
+    <hr class="mt-6">
+  <% end %>
+</div>

--- a/app/views/headings/_heading.json.jbuilder
+++ b/app/views/headings/_heading.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.extract! heading, :id, :category_id, :subcategory_id, :created_at, :updated_at
+json.url heading_url(heading, format: :json)

--- a/app/views/headings/edit.html.erb
+++ b/app/views/headings/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">Editing heading</h1>
+
+  <%= render "form", heading: @heading %>
+
+  <%= link_to "Show this heading", @heading, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%= link_to "Back to headings", headings_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/app/views/headings/index.html.erb
+++ b/app/views/headings/index.html.erb
@@ -1,0 +1,14 @@
+<div class="w-full">
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+  <% end %>
+
+  <div class="flex justify-between items-center">
+    <h1 class="font-bold text-4xl">Headings</h1>
+    <%= link_to 'New heading', new_heading_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
+  </div>
+
+  <div id="headings" class="min-w-full">
+    <%= render @headings %>
+  </div>
+</div>

--- a/app/views/headings/index.json.jbuilder
+++ b/app/views/headings/index.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @headings, partial: 'headings/heading', as: :heading

--- a/app/views/headings/new.html.erb
+++ b/app/views/headings/new.html.erb
@@ -1,0 +1,7 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">New heading</h1>
+
+  <%= render "form", heading: @heading %>
+
+  <%= link_to 'Back to headings', headings_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -1,0 +1,15 @@
+<div class="mx-auto md:w-2/3 w-full flex">
+  <div class="mx-auto">
+    <% if notice.present? %>
+      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+    <% end %>
+
+    <%= render @heading %>
+
+    <%= link_to 'Edit this heading', edit_heading_path(@heading), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <div class="inline-block ml-2">
+      <%= button_to 'Destroy this heading', heading_path(@heading), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+    </div>
+    <%= link_to 'Back to headings', headings_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  </div>
+</div>

--- a/app/views/headings/show.json.jbuilder
+++ b/app/views/headings/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! 'headings/heading', heading: @heading

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,8 @@
 <nav class="ml-20">
 <%= link_to 'Vendors', vendors_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
 <%= link_to 'Databases', databases_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+<%= link_to 'Headings', headings_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+<%= link_to 'Categories', categories_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+<%= link_to 'Subcategories', subcategories_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+
 </nav>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,7 +7,7 @@
                     <%= image_tag "libraries.logo.small.horizontal.blue.png", class: "h-32 w-auto" %>
                 <div class="xs-hidden pl-10 py-4 space-x-8 lg:block border-l border-jhublue">
                     <h1 class="text-4xl text-medium font-body">
-                        <span class="text-jhublue">Hummingbird</span>
+                        <span class="text-jhublue"><a href="/">Databases</a></span>
                     </h1>
                 </div>
             </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Hummingbird</title>
+    <title>Databases</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -11,7 +11,9 @@
   </head>
   <%= render "layouts/header" %>
    <body>
-    <%= yield %>
+    <div class="mx-16 main-container">
+      <%= yield %>
+    </div>
   </body>
   <%= render "layouts/footer" %>
 </html>

--- a/app/views/subcategories/_form.html.erb
+++ b/app/views/subcategories/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: subcategory, class: "contents") do |form| %>
+  <% if subcategory.errors.any? %>
+    <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
+      <h2><%= pluralize(subcategory.errors.count, "error") %> prohibited this subcategory from being saved:</h2>
+
+      <ul>
+        <% subcategory.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="my-5">
+    <%= form.label :label %>
+    <%= form.text_field :label, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+  </div>
+
+  <div class="inline">
+    <%= form.submit class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+  </div>
+<% end %>

--- a/app/views/subcategories/_subcategory.html.erb
+++ b/app/views/subcategories/_subcategory.html.erb
@@ -1,0 +1,12 @@
+<div id="<%= dom_id subcategory %>">
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Label:</strong>
+    <%= subcategory.label %>
+  </p>
+
+  <% if action_name != "show" %>
+    <%= link_to "Show this subcategory", subcategory, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to 'Edit this subcategory', edit_subcategory_path(subcategory), class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
+    <hr class="mt-6">
+  <% end %>
+</div>

--- a/app/views/subcategories/_subcategory.json.jbuilder
+++ b/app/views/subcategories/_subcategory.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.extract! subcategory, :id, :label, :created_at, :updated_at
+json.url subcategory_url(subcategory, format: :json)

--- a/app/views/subcategories/edit.html.erb
+++ b/app/views/subcategories/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">Editing subcategory</h1>
+
+  <%= render "form", subcategory: @subcategory %>
+
+  <%= link_to "Show this subcategory", @subcategory, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%= link_to "Back to subcategories", subcategories_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/app/views/subcategories/index.html.erb
+++ b/app/views/subcategories/index.html.erb
@@ -1,0 +1,14 @@
+<div class="w-full">
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+  <% end %>
+
+  <div class="flex justify-between items-center">
+    <h1 class="font-bold text-4xl">Subcategories</h1>
+    <%= link_to 'New subcategory', new_subcategory_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
+  </div>
+
+  <div id="subcategories" class="min-w-full">
+    <%= render @subcategories %>
+  </div>
+</div>

--- a/app/views/subcategories/index.json.jbuilder
+++ b/app/views/subcategories/index.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @subcategories, partial: 'subcategories/subcategory', as: :subcategory

--- a/app/views/subcategories/new.html.erb
+++ b/app/views/subcategories/new.html.erb
@@ -1,0 +1,7 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">New subcategory</h1>
+
+  <%= render "form", subcategory: @subcategory %>
+
+  <%= link_to 'Back to subcategories', subcategories_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/app/views/subcategories/show.html.erb
+++ b/app/views/subcategories/show.html.erb
@@ -1,0 +1,15 @@
+<div class="mx-auto md:w-2/3 w-full flex">
+  <div class="mx-auto">
+    <% if notice.present? %>
+      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+    <% end %>
+
+    <%= render @subcategory %>
+
+    <%= link_to 'Edit this subcategory', edit_subcategory_path(@subcategory), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <div class="inline-block ml-2">
+      <%= button_to 'Destroy this subcategory', subcategory_path(@subcategory), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+    </div>
+    <%= link_to 'Back to subcategories', subcategories_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  </div>
+</div>

--- a/app/views/subcategories/show.json.jbuilder
+++ b/app/views/subcategories/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! 'subcategories/subcategory', subcategory: @subcategory

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  resources :database_headings
+  resources :headings
+  resources :subcategories
+  resources :categories
   resources :databases
   resources :vendors
   devise_for :users

--- a/db/migrate/20220601150043_create_categories.rb
+++ b/db/migrate/20220601150043_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :categories do |t|
+      t.string :label
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220601150058_create_subcategories.rb
+++ b/db/migrate/20220601150058_create_subcategories.rb
@@ -1,0 +1,9 @@
+class CreateSubcategories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :subcategories do |t|
+      t.string :label
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220601150146_create_headings.rb
+++ b/db/migrate/20220601150146_create_headings.rb
@@ -1,0 +1,10 @@
+class CreateHeadings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :headings do |t|
+      t.references :category, null: false, foreign_key: true
+      t.references :subcategory, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220601150254_create_database_headings.rb
+++ b/db/migrate/20220601150254_create_database_headings.rb
@@ -1,0 +1,10 @@
+class CreateDatabaseHeadings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :database_headings do |t|
+      t.references :database, null: false, foreign_key: true
+      t.references :heading, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_31_201129) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_01_150254) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string "label"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "database_headings", force: :cascade do |t|
+    t.bigint "database_id", null: false
+    t.bigint "heading_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["database_id"], name: "index_database_headings_on_database_id"
+    t.index ["heading_id"], name: "index_database_headings_on_heading_id"
+  end
 
   create_table "databases", force: :cascade do |t|
     t.bigint "vendor_id", null: false
@@ -28,6 +43,21 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_31_201129) do
     t.index ["name"], name: "index_databases_on_name", unique: true
     t.index ["url"], name: "index_databases_on_url", unique: true
     t.index ["vendor_id"], name: "index_databases_on_vendor_id"
+  end
+
+  create_table "headings", force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.bigint "subcategory_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_headings_on_category_id"
+    t.index ["subcategory_id"], name: "index_headings_on_subcategory_id"
+  end
+
+  create_table "subcategories", force: :cascade do |t|
+    t.string "label"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -49,5 +79,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_31_201129) do
     t.index ["brand_name"], name: "index_vendors_on_brand_name", unique: true
   end
 
+  add_foreign_key "database_headings", "databases"
+  add_foreign_key "database_headings", "headings"
   add_foreign_key "databases", "vendors"
+  add_foreign_key "headings", "categories"
+  add_foreign_key "headings", "subcategories"
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :category do
+    label { FFaker::Education.major }
+  end
+end

--- a/spec/factories/database_headings.rb
+++ b/spec/factories/database_headings.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :database_heading do
+    database { FactoryBot.create(:database) }
+    heading { FactoryBot.create(:heading) }
+  end
+end

--- a/spec/factories/headings.rb
+++ b/spec/factories/headings.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :heading do
+    category { FactoryBot.create(:category) }
+    subcategory { FactoryBot.create(:subcategory) }
+  end
+end

--- a/spec/factories/subcategories.rb
+++ b/spec/factories/subcategories.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :subcategory do
+    label { FFaker::Education.major }
+  end
+end

--- a/spec/models/heading_spec.rb
+++ b/spec/models/heading_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Heading, type: :model do
+  let(:heading) { FactoryBot.create(:heading) }
+
+  describe 'getting a label for a heading' do
+    it 'can get a formatted label' do
+      expect(heading.label).to eq("#{heading.category.label} – #{heading.subcategory.label}")
+    end
+  end
+end

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '/categories', type: :request do
+  let(:vendor) { FactoryBot.create(:vendor) }
+  let(:category) { FactoryBot.create(:category) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:required_attributes) do
+    { label: FFaker::Education.major }
+  end
+
+  before do
+    sign_in user
+    vendor.save!
+    category.save!
+  end
+
+  describe 'GET /index' do
+    it 'renders a successful response' do
+      get categories_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /show' do
+    it 'renders a successful response' do
+      get category_url(category)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /new' do
+    it 'renders a successful response' do
+      get new_category_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /edit' do
+    it 'renders a successful response' do
+      get edit_category_url(category)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters' do
+      it 'creates a new Category' do
+        expect do
+          post categories_url, params: { category: required_attributes }
+        end.to change(Category, :count).by(1)
+      end
+
+      it 'redirects to the created category' do
+        post categories_url, params: { category: required_attributes }
+        expect(response).to redirect_to(category_url(Category.last))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new Category' do
+        allow_any_instance_of(Category).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+
+        put category_url(category), params: { category: { id: '1' } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders a response with 422 status (i.e. to display the 'new' template)" do
+        allow_any_instance_of(Category).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+        post categories_url, params: { category: { id: '1' } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'PATCH /update' do
+    context 'with valid parameters' do
+      it 'updates the requested category' do
+        patch category_url(category), params: { category: category.attributes }
+        category.reload
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'redirects to the category' do
+        patch category_url(category), params: { category: category.attributes }
+        category.reload
+        expect(response).to redirect_to(category_url(category))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+        allow_any_instance_of(Category).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+
+        patch category_url(category), params: { category: { id: '1' } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the requested category' do
+      expect do
+        delete category_url(category)
+      end.to change(Category, :count).by(-1)
+    end
+
+    it 'redirects to the categories list' do
+      delete category_url(category)
+      expect(response).to redirect_to(categories_url)
+    end
+  end
+end

--- a/spec/requests/database_headings_spec.rb
+++ b/spec/requests/database_headings_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '/database_headings', type: :request do
+  let(:vendor) { FactoryBot.create(:vendor) }
+  let(:subcategory) { FactoryBot.create(:subcategory) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:required_attributes) do
+    { category: 1, subcategory: 1 }
+  end
+
+  before do
+    sign_in user
+    vendor.save!
+    subcategory.save!
+  end
+
+  describe 'GET /index' do
+    it 'renders a successful response' do
+      get subcategories_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /show' do
+    it 'renders a successful response' do
+      get subcategory_url(subcategory)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /new' do
+    it 'renders a successful response' do
+      get new_subcategory_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /edit' do
+    it 'renders a successful response' do
+      get edit_subcategory_url(subcategory)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters' do
+      it 'creates a new Subcategory' do
+        expect do
+          post subcategories_url, params: { subcategory: required_attributes }
+        end.to change(Subcategory, :count).by(1)
+      end
+
+      it 'redirects to the created subcategory' do
+        post subcategories_url, params: { subcategory: required_attributes }
+        expect(response).to redirect_to(subcategory_url(Subcategory.last))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new Subcategory' do
+        allow_any_instance_of(Subcategory).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+
+        put subcategory_url(subcategory), params: { subcategory: { id: '1' } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders a response with 422 status (i.e. to display the 'new' template)" do
+        allow_any_instance_of(Subcategory).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+        post subcategories_url, params: { subcategory: { id: '1' } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'PATCH /update' do
+    context 'with valid parameters' do
+      it 'updates the requested subcategory' do
+        patch subcategory_url(subcategory), params: { subcategory: subcategory.attributes }
+        subcategory.reload
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'redirects to the subcategory' do
+        patch subcategory_url(subcategory), params: { subcategory: subcategory.attributes }
+        subcategory.reload
+        expect(response).to redirect_to(subcategory_url(subcategory))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+        allow_any_instance_of(Subcategory).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+
+        patch subcategory_url(subcategory), params: { subcategory: { id: '1' } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the requested subcategory' do
+      expect do
+        delete subcategory_url(subcategory)
+      end.to change(Subcategory, :count).by(-1)
+    end
+
+    it 'redirects to the categories list' do
+      delete subcategory_url(subcategory)
+      expect(response).to redirect_to(subcategories_url)
+    end
+  end
+end

--- a/spec/requests/headings_spec.rb
+++ b/spec/requests/headings_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '/headings', type: :request do
+  let!(:heading) { FactoryBot.create(:heading) }
+  let(:user) { FactoryBot.create(:user) }
+  let!(:category) { FactoryBot.create(:category) }
+  let!(:subcategory) { FactoryBot.create(:subcategory) }
+  let(:required_attributes) do
+    { category_id: category.id, subcategory_id: subcategory.id }
+  end
+
+  before do
+    sign_in user
+    category.save!
+    subcategory.save!
+    heading.save!
+  end
+
+  describe 'GET /index' do
+    it 'renders a successful response' do
+      get headings_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /show' do
+    it 'renders a successful response' do
+      get heading_url(heading)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /new' do
+    it 'renders a successful response' do
+      get new_heading_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /edit' do
+    it 'renders a successful response' do
+      get edit_heading_url(heading)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters' do
+      it 'creates a new Heading' do
+        expect do
+          post headings_url, params: { heading: required_attributes }
+        end.to change(Heading, :count).by(1)
+      end
+
+      it 'redirects to the created heading' do
+        post headings_url, params: { heading: required_attributes }
+        expect(response).to redirect_to(heading_url(Heading.last))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new Heading' do
+        allow_any_instance_of(Heading).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+
+        put heading_url(heading), params: { heading: { id: '1' } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders a response with 422 status (i.e. to display the 'new' template)" do
+        allow_any_instance_of(Heading).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+        post headings_url, params: { heading: { id: '1' } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'PATCH /update' do
+    context 'with valid parameters' do
+      it 'updates the requested heading' do
+        patch heading_url(heading), params: { heading: heading.attributes }
+        heading.reload
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'redirects to the heading' do
+        patch heading_url(heading), params: { heading: heading.attributes }
+        heading.reload
+        expect(response).to redirect_to(heading_url(heading))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+        allow_any_instance_of(Heading).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+
+        patch heading_url(heading), params: { heading: { id: '1' } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the requested heading' do
+      expect do
+        delete heading_url(heading)
+      end.to change(Heading, :count).by(-1)
+    end
+
+    it 'redirects to the categories list' do
+      delete heading_url(heading)
+      expect(response).to redirect_to(headings_url)
+    end
+  end
+end

--- a/spec/requests/subcategories_spec.rb
+++ b/spec/requests/subcategories_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '/subcategories', type: :request do
+  let(:vendor) { FactoryBot.create(:vendor) }
+  let(:subcategory) { FactoryBot.create(:subcategory) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:required_attributes) do
+    { label: FFaker::Education.major }
+  end
+
+  before do
+    sign_in user
+    vendor.save!
+    subcategory.save!
+  end
+
+  describe 'GET /index' do
+    it 'renders a successful response' do
+      get subcategories_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /show' do
+    it 'renders a successful response' do
+      get subcategory_url(subcategory)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /new' do
+    it 'renders a successful response' do
+      get new_subcategory_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /edit' do
+    it 'renders a successful response' do
+      get edit_subcategory_url(subcategory)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters' do
+      it 'creates a new Subcategory' do
+        expect do
+          post subcategories_url, params: { subcategory: required_attributes }
+        end.to change(Subcategory, :count).by(1)
+      end
+
+      it 'redirects to the created subcategory' do
+        post subcategories_url, params: { subcategory: required_attributes }
+        expect(response).to redirect_to(subcategory_url(Subcategory.last))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new Subcategory' do
+        allow_any_instance_of(Subcategory).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+
+        put subcategory_url(subcategory), params: { subcategory: { id: '1' } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders a response with 422 status (i.e. to display the 'new' template)" do
+        allow_any_instance_of(Subcategory).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+        post subcategories_url, params: { subcategory: { id: '1' } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'PATCH /update' do
+    context 'with valid parameters' do
+      it 'updates the requested subcategory' do
+        patch subcategory_url(subcategory), params: { subcategory: subcategory.attributes }
+        subcategory.reload
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'redirects to the subcategory' do
+        patch subcategory_url(subcategory), params: { subcategory: subcategory.attributes }
+        subcategory.reload
+        expect(response).to redirect_to(subcategory_url(subcategory))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+        allow_any_instance_of(Subcategory).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+
+        patch subcategory_url(subcategory), params: { subcategory: { id: '1' } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the requested subcategory' do
+      expect do
+        delete subcategory_url(subcategory)
+      end.to change(Subcategory, :count).by(-1)
+    end
+
+    it 'redirects to the categories list' do
+      delete subcategory_url(subcategory)
+      expect(response).to redirect_to(subcategories_url)
+    end
+  end
+end

--- a/spec/system/categories_spec.rb
+++ b/spec/system/categories_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Category CRUD Operations', type: :system do # rubocop:disable RSpec/MultipleMemoizedHelpers
+  let(:user) { FactoryBot.create(:user) }
+  let(:vendor) { FactoryBot.create(:category) }
+  let(:database) { FactoryBot.create(:database) }
+  let(:heading) { FactoryBot.create(:heading) }
+  let(:category) { FactoryBot.create(:category) }
+  let(:subcategory) { FactoryBot.create(:subcategory) }
+  let(:database_heading) { FactoryBot.create(:database_heading) }
+
+  before do
+    driven_by(:selenium_chrome_headless)
+    visit root_path
+
+    category.save!
+
+    click_link 'Log in'
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+    click_button 'Log in'
+  end
+
+  it 'can create a category' do
+    visit '/categories'
+
+    click_on 'New category'
+    fill_in 'Label', with: FFaker::Education.major
+
+    click_on 'Create Category'
+
+    expect(page).to have_content('Category was successfully created.')
+  end
+
+  it 'can update a category' do
+    visit '/categories'
+
+    click_on 'Edit this category'
+    fill_in 'Label', with: FFaker::Company.name
+    click_on 'Update Category'
+
+    expect(page).to have_content('Category was successfully updated.')
+  end
+
+  it 'can delete category' do
+    visit '/categories'
+    click_on 'Show this category'
+    click_on 'Destroy this category'
+
+    expect(page).to have_content('Category was successfully destroyed.')
+  end
+end

--- a/spec/system/database_headings_spec.rb
+++ b/spec/system/database_headings_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Heading CRUD Operations', type: :system do # rubocop:disable RSpec/MultipleMemoizedHelpers
+  let(:user) { FactoryBot.create(:user) }
+  let(:database) { FactoryBot.create(:database) }
+  let(:database_heading) { FactoryBot.create(:database_heading) }
+  let(:heading) { FactoryBot.create(:heading) }
+  let(:category) { FactoryBot.create(:category) }
+  let(:subcategory) { FactoryBot.create(:subcategory) }
+
+  before do
+    driven_by(:selenium_chrome_headless)
+    visit root_path
+
+    click_link 'Log in'
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+    click_button 'Log in'
+  end
+
+  it 'can create a database heading' do
+    database.save!
+    heading.save!
+    visit '/database_headings'
+
+    click_on 'New database heading'
+    select database.name, from: 'Database'
+    select heading.label, from: 'Heading'
+    click_on 'Create Database heading'
+
+    expect(page).to have_content('Database heading was successfully created.')
+  end
+
+  it 'can update a database heading' do
+    database_heading.save!
+    visit '/database_headings'
+
+    click_on 'Edit this database heading'
+    click_on 'Update Database heading'
+
+    expect(page).to have_content('Database heading was successfully updated.')
+  end
+
+  it 'can delete a database heading' do
+    database_heading.save!
+    visit '/database_headings'
+
+    click_on 'Show this database heading'
+    click_on 'Destroy this database_heading'
+
+    expect(page).to have_content('Database heading was successfully destroyed.')
+  end
+end

--- a/spec/system/databases_spec.rb
+++ b/spec/system/databases_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Database CRUD Operations', type: :system do
   let(:user) { FactoryBot.create(:user) }
   let(:vendor) { FactoryBot.create(:vendor) }
-  let(:database) { FactoryBot.create(:vendor) }
+  let(:database) { FactoryBot.create(:database) }
 
   before do
     driven_by(:selenium_chrome_headless)

--- a/spec/system/headings_spec.rb
+++ b/spec/system/headings_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Heading CRUD Operations', type: :system do
+  let(:user) { FactoryBot.create(:user) }
+  let(:heading) { FactoryBot.create(:heading) }
+  let(:category) { FactoryBot.create(:category) }
+  let(:subcategory) { FactoryBot.create(:subcategory) }
+
+  before do
+    driven_by(:selenium_chrome_headless)
+    visit root_path
+
+    category.save!
+    subcategory.save!
+
+    click_link 'Log in'
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+    click_button 'Log in'
+  end
+
+  it 'can create a heading' do
+    visit '/headings'
+
+    click_on 'New heading'
+    select category.label, from: 'Category'
+    select subcategory.label, from: 'Subcategory'
+    click_on 'Create Heading'
+
+    expect(page).to have_content('Heading was successfully created.')
+  end
+
+  it 'can update a heading' do
+    heading.save!
+    visit '/headings'
+    click_on 'Edit this heading'
+    select category.label, from: 'Category'
+    select subcategory.label, from: 'Subcategory'
+    click_on 'Update Heading'
+
+    expect(page).to have_content('Heading was successfully updated.')
+  end
+
+  it 'can delete heading' do
+    heading.save!
+    visit '/headings'
+    click_on 'Show this heading'
+    click_on 'Destroy this heading'
+
+    expect(page).to have_content('Heading was successfully destroyed.')
+  end
+end

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe 'HomePages', type: :system do
 
   it 'is accessible' do
     visit root_path
-    expect(page).to have_content('Hummingbird')
+    expect(page).to have_content('Databases')
   end
 end

--- a/spec/system/subcategories_spec.rb
+++ b/spec/system/subcategories_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Category CRUD Operations', type: :system do # rubocop:disable RSpec/MultipleMemoizedHelpers
+  let(:user) { FactoryBot.create(:user) }
+  let(:vendor) { FactoryBot.create(:vendor) }
+  let(:database) { FactoryBot.create(:database) }
+  let(:heading) { FactoryBot.create(:heading) }
+  let(:category) { FactoryBot.create(:category) }
+  let(:subcategory) { FactoryBot.create(:subcategory) }
+  let(:database_heading) { FactoryBot.create(:database_heading) }
+
+  before do
+    driven_by(:selenium_chrome_headless)
+    visit root_path
+
+    subcategory.save!
+
+    click_link 'Log in'
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+    click_button 'Log in'
+  end
+
+  it 'can create a subcategory' do
+    visit '/subcategories'
+
+    click_on 'New subcategory'
+    fill_in 'Label', with: FFaker::Education.major
+
+    click_on 'Create Subcategory'
+
+    expect(page).to have_content('Subcategory was successfully created.')
+  end
+
+  it 'can update a subcategory' do
+    visit '/subcategories'
+
+    click_on 'Edit this subcategory'
+    fill_in 'Label', with: FFaker::Company.name
+    click_on 'Update Subcategory'
+
+    expect(page).to have_content('Subcategory was successfully updated.')
+  end
+
+  it 'can delete subcategory' do
+    visit '/subcategories'
+    click_on 'Show this subcategory'
+    click_on 'Destroy this subcategory'
+
+    expect(page).to have_content('Subcategory was successfully destroyed.')
+  end
+end


### PR DESCRIPTION
This adds CRUD for Headings.

This PR has additional database migrations. After
checking out this branch you'll need to run
`docker-compose run --rm hummingbird bundle exec rake db:migrate`
to update the database.

You can test the functionality by logging in and visiting
`/categories/`, `/subcategories/`, `/headings/` and
`/database_headings`.

You'll need to create a a category and a subcategory. After that
you'll be able to create a heading, which is a combination of a
category and subcategory. Then you can associate a database
with a heading.

These are the most basic forms for this functionality. We'll
need to combine some of the forms so that you don't need to
visit the `/database_headings` forms to add a heading to a database.