### PR TITLE
LAGJH-1047 CRUD for Headings.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,8 +14,16 @@ RSpec/ExampleLength:
   Exclude:
   - 'spec/**/*.rb'
 
+RSpec/MultipleMemoizedHelpers:
+  Exclude:
+  - 'spec/**/*.rb'
+
 AllCops:
   Exclude:
     - 'db/schema.rb'
     - 'config/initializers/*'
     - 'db/migrate/*'
+    
+Style/Documentation:
+  Exclude:
+   - '**/*'

--- a/app/controllers/database_headings_controller.rb
+++ b/app/controllers/database_headings_controller.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class DatabaseHeadingsController < ApplicationController
+  before_action :set_database_heading, only: %i[show edit update destroy]
+  before_action :require_login
+
+  # GET /database_headings or /database_headings.json
+  def index
+    @database_headings = DatabaseHeading.all
+  end
+
+  # GET /database_headings/1 or /database_headings/1.json
+  def show; end
+
+  # GET /database_headings/new
+  def new
+    @database_heading = DatabaseHeading.new
+  end
+
+  # GET /database_headings/1/edit
+  def edit; end
+
+  # POST /database_headings or /database_headings.json
+  def create # rubocop:disable Metrics/MethodLength
+    @database_heading = DatabaseHeading.new(database_heading_params)
+
+    respond_to do |format|
+      if @database_heading.save
+        format.html do
+          redirect_to database_heading_url(@database_heading), notice: 'Database heading was successfully created.'
+        end
+        format.json { render :show, status: :created, location: @database_heading }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @database_heading.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /database_headings/1 or /database_headings/1.json
+  def update # rubocop:disable Metrics/MethodLength
+    respond_to do |format|
+      if @database_heading.update(database_heading_params)
+        format.html do
+          redirect_to database_heading_url(@database_heading), notice: 'Database heading was successfully updated.'
+        end
+        format.json { render :show, status: :ok, location: @database_heading }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @database_heading.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /database_headings/1 or /database_headings/1.json
+  def destroy
+    @database_heading.destroy
+
+    respond_to do |format|
+      format.html { redirect_to database_headings_url, notice: 'Database heading was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  # Require login
+  def require_login
+    redirect_to new_user_session_path if current_user.blank?
+  end
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_database_heading
+    @database_heading = DatabaseHeading.find(params[:id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def database_heading_params
+    params.require(:database_heading).permit(:jhu_id, :heading_id, :subheading_id, :database_id)
+  end
+end

--- a/app/controllers/headings_controller.rb
+++ b/app/controllers/headings_controller.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+class HeadingsController < ApplicationController
+  before_action :set_heading, only: %i[show edit update destroy]
+  before_action :require_login
+
+  # GET /headings or /headings.json
+  def index
+    @headings = Heading.all
+  end
+
+  # GET /headings/1 or /headings/1.json
+  def show; end
+
+  # GET /headings/new
+  def new
+    @heading = Heading.new
+  end
+
+  # GET /headings/1/edit
+  def edit; end
+
+  # POST /headings or /headings.json
+  def create
+    @heading = Heading.new(heading_params)
+
+    respond_to do |format|
+      if @heading.save
+        format.html { redirect_to heading_url(@heading), notice: 'Heading was successfully created.' }
+        format.json { render :show, status: :created, location: @heading }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @heading.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /headings/1 or /headings/1.json
+  def update
+    respond_to do |format|
+      if @heading.update(heading_params)
+        format.html { redirect_to heading_url(@heading), notice: 'Heading was successfully updated.' }
+        format.json { render :show, status: :ok, location: @heading }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @heading.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /headings/1 or /headings/1.json
+  def destroy
+    @heading.destroy
+
+    respond_to do |format|
+      format.html { redirect_to headings_url, notice: 'Heading was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_heading
+    @heading = Heading.find(params[:id])
+  end
+
+  # Require login
+  def require_login
+    redirect_to new_user_session_path if current_user.blank?
+  end
+
+  # Only allow a list of trusted parameters through.
+  def heading_params
+    params.require(:heading).permit(:label)
+  end
+end

--- a/app/controllers/subheadings_controller.rb
+++ b/app/controllers/subheadings_controller.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+class SubheadingsController < ApplicationController
+  before_action :set_subheading, only: %i[show edit update destroy]
+  before_action :require_login
+
+  # GET /subheadings or /subheadings.json
+  def index
+    @subheadings = Subheading.all
+  end
+
+  # GET /subheadings/1 or /subheadings/1.json
+  def show; end
+
+  # GET /subheadings/new
+  def new
+    @subheading = Subheading.new
+  end
+
+  # GET /subheadings/1/edit
+  def edit; end
+
+  # POST /subheadings or /subheadings.json
+  def create
+    @subheading = Subheading.new(subheading_params)
+
+    respond_to do |format|
+      if @subheading.save
+        format.html { redirect_to subheading_url(@subheading), notice: 'Subheading was successfully created.' }
+        format.json { render :show, status: :created, location: @subheading }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @subheading.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /subheadings/1 or /subheadings/1.json
+  def update
+    respond_to do |format|
+      if @subheading.update(subheading_params)
+        format.html { redirect_to subheading_url(@subheading), notice: 'Subheading was successfully updated.' }
+        format.json { render :show, status: :ok, location: @subheading }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @subheading.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /subheadings/1 or /subheadings/1.json
+  def destroy
+    @subheading.destroy
+
+    respond_to do |format|
+      format.html { redirect_to subheadings_url, notice: 'Subheading was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  # Require login
+  def require_login
+    redirect_to new_user_session_path if current_user.blank?
+  end
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_subheading
+    @subheading = Subheading.find(params[:id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def subheading_params
+    params.require(:subheading).permit(:label)
+  end
+end

--- a/app/helpers/database_headings_helper.rb
+++ b/app/helpers/database_headings_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module DatabaseHeadingsHelper
+end

--- a/app/helpers/headings_helper.rb
+++ b/app/helpers/headings_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module HeadingsHelper
+end

--- a/app/helpers/subheadings_helper.rb
+++ b/app/helpers/subheadings_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module SubheadingsHelper
+end

--- a/app/models/database.rb
+++ b/app/models/database.rb
@@ -7,4 +7,10 @@ class Database < ApplicationRecord
   validates :url, uniqueness: true, presence: true
   validates :name, uniqueness: true, presence: true
   validates :jhu_id, uniqueness: true, presence: true
+
+  has_many :database_headings, dependent: :destroy
+
+  def label
+    "#{name} (#{jhu_id})"
+  end
 end

--- a/app/models/database_heading.rb
+++ b/app/models/database_heading.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class DatabaseHeading < ApplicationRecord
+  belongs_to :heading
+  belongs_to :subheading
+  belongs_to :database
+  before_save :set_jhu_id
+
+  private
+
+  def set_jhu_id
+    self.jhu_id = Database.find(database.id).jhu_id
+  end
+end

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Heading < ApplicationRecord
+end

--- a/app/models/subheading.rb
+++ b/app/models/subheading.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Subheading < ApplicationRecord
+end

--- a/app/views/database_headings/_database_heading.html.erb
+++ b/app/views/database_headings/_database_heading.html.erb
@@ -1,0 +1,22 @@
+<div id="<%= dom_id database_heading %>">
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Database:</strong>
+    <%= Database.find(database_heading.database_id).label %>
+  </p>
+
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Heading:</strong>
+    <%= Heading.find(database_heading.heading_id).label %>
+  </p>
+
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Subheading:</strong>
+    <%= Subheading.find(database_heading.subheading_id).label %>
+  </p>
+
+  <% if action_name != "show" %>
+    <%= link_to "Show this database heading", database_heading, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to 'Edit this database heading', edit_database_heading_path(database_heading), class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
+    <hr class="mt-6">
+  <% end %>
+</div>

--- a/app/views/database_headings/_database_heading.json.jbuilder
+++ b/app/views/database_headings/_database_heading.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.extract! database_heading, :id, :jhu_id, :heading_id, :subheading_id, :created_at, :updated_at
+json.url database_heading_url(database_heading, format: :json)

--- a/app/views/database_headings/_form.html.erb
+++ b/app/views/database_headings/_form.html.erb
@@ -1,0 +1,8 @@
+<%= simple_form_for @database_heading do |f| %>
+  <%= f.association :database, label_method: :label, value_method: :id, include_blank: false,  label: 'Database' %>
+  <%= f.association :heading, label_method: :label, value_method: :id, include_blank: false,  label: 'Heading' %>
+  <%= f.association :subheading, label_method: :label, value_method: :id, include_blank: false,  label: 'Subheading' %>
+
+
+  <%= f.button :submit %>
+<% end %>

--- a/app/views/database_headings/edit.html.erb
+++ b/app/views/database_headings/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">Editing database heading</h1>
+
+  <%= render "form", database_heading: @database_heading %>
+
+  <%= link_to "Show this database heading", @database_heading, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%= link_to "Back to database headings", database_headings_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/app/views/database_headings/index.html.erb
+++ b/app/views/database_headings/index.html.erb
@@ -1,0 +1,14 @@
+<div class="w-full">
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+  <% end %>
+
+  <div class="flex justify-between items-center">
+    <h1 class="font-bold text-4xl">Database headings</h1>
+    <%= link_to 'New database heading', new_database_heading_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
+  </div>
+
+  <div id="database_headings" class="min-w-full">
+    <%= render @database_headings %>
+  </div>
+</div>

--- a/app/views/database_headings/index.json.jbuilder
+++ b/app/views/database_headings/index.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @database_headings, partial: 'database_headings/database_heading', as: :database_heading

--- a/app/views/database_headings/new.html.erb
+++ b/app/views/database_headings/new.html.erb
@@ -1,0 +1,7 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">New database heading</h1>
+
+  <%= render "form", database_heading: @database_heading %>
+
+  <%= link_to 'Back to database headings', database_headings_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/app/views/database_headings/show.html.erb
+++ b/app/views/database_headings/show.html.erb
@@ -1,0 +1,15 @@
+<div class="mx-auto md:w-2/3 w-full flex">
+  <div class="mx-auto">
+    <% if notice.present? %>
+      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+    <% end %>
+
+    <%= render @database_heading %>
+
+    <%= link_to 'Edit this database_heading', edit_database_heading_path(@database_heading), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <div class="inline-block ml-2">
+      <%= button_to 'Destroy this database_heading', database_heading_path(@database_heading), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+    </div>
+    <%= link_to 'Back to database_headings', database_headings_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  </div>
+</div>

--- a/app/views/database_headings/show.json.jbuilder
+++ b/app/views/database_headings/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! 'database_headings/database_heading', database_heading: @database_heading

--- a/app/views/headings/_form.html.erb
+++ b/app/views/headings/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: heading, class: "contents") do |form| %>
+  <% if heading.errors.any? %>
+    <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
+      <h2><%= pluralize(heading.errors.count, "error") %> prohibited this heading from being saved:</h2>
+
+      <ul>
+        <% heading.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="my-5">
+    <%= form.label :label %>
+    <%= form.text_field :label, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+  </div>
+
+  <div class="inline">
+    <%= form.submit class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+  </div>
+<% end %>

--- a/app/views/headings/_heading.html.erb
+++ b/app/views/headings/_heading.html.erb
@@ -1,0 +1,12 @@
+<div id="<%= dom_id heading %>">
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Label:</strong>
+    <%= heading.label %>
+  </p>
+
+  <% if action_name != "show" %>
+    <%= link_to "Show this heading", heading, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to 'Edit this heading', edit_heading_path(heading), class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
+    <hr class="mt-6">
+  <% end %>
+</div>

--- a/app/views/headings/_heading.json.jbuilder
+++ b/app/views/headings/_heading.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.extract! heading, :id, :label, :created_at, :updated_at
+json.url heading_url(heading, format: :json)

--- a/app/views/headings/edit.html.erb
+++ b/app/views/headings/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">Editing heading</h1>
+
+  <%= render "form", heading: @heading %>
+
+  <%= link_to "Show this heading", @heading, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%= link_to "Back to headings", headings_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/app/views/headings/index.html.erb
+++ b/app/views/headings/index.html.erb
@@ -1,0 +1,14 @@
+<div class="w-full">
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+  <% end %>
+
+  <div class="flex justify-between items-center">
+    <h1 class="font-bold text-4xl">Headings</h1>
+    <%= link_to 'New heading', new_heading_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
+  </div>
+
+  <div id="headings" class="min-w-full">
+    <%= render @headings %>
+  </div>
+</div>

--- a/app/views/headings/index.json.jbuilder
+++ b/app/views/headings/index.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @headings, partial: 'headings/heading', as: :heading

--- a/app/views/headings/new.html.erb
+++ b/app/views/headings/new.html.erb
@@ -1,0 +1,7 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">New heading</h1>
+
+  <%= render "form", heading: @heading %>
+
+  <%= link_to 'Back to headings', headings_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -1,0 +1,15 @@
+<div class="mx-auto md:w-2/3 w-full flex">
+  <div class="mx-auto">
+    <% if notice.present? %>
+      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+    <% end %>
+
+    <%= render @heading %>
+
+    <%= link_to 'Edit this heading', edit_heading_path(@heading), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <div class="inline-block ml-2">
+      <%= button_to 'Destroy this heading', heading_path(@heading), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+    </div>
+    <%= link_to 'Back to headings', headings_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  </div>
+</div>

--- a/app/views/headings/show.json.jbuilder
+++ b/app/views/headings/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! 'headings/heading', heading: @heading

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,7 @@
-<nav class="ml-20">
-<%= link_to 'Vendors', vendors_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
-<%= link_to 'Databases', databases_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+<nav>
+  <%= link_to 'Vendors', vendors_path, class: "ml-2 rounded-lg py-3 px-5 bg-jhublue text-white inline-block font-medium" %>
+  <%= link_to 'Databases', databases_path, class: "ml-2 rounded-lg py-3 px-5 bg-jhublue text-white inline-block font-medium" %>
+  <%= link_to 'Headings', headings_path, class: "ml-2 rounded-lg py-3 px-5 bg-jhublue text-white inline-block font-medium" %>
+  <%= link_to 'Subheadings', subheadings_path, class: "ml-2 rounded-lg py-3 px-5 bg-jhublue text-white inline-block font-medium" %>
+  <%= link_to 'Database Headings', database_headings_path, class: "ml-2 rounded-lg py-3 px-5 bg-jhublue text-white inline-block font-medium" %>
 </nav>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,7 +7,7 @@
                     <%= image_tag "libraries.logo.small.horizontal.blue.png", class: "h-32 w-auto" %>
                 <div class="xs-hidden pl-10 py-4 space-x-8 lg:block border-l border-jhublue">
                     <h1 class="text-4xl text-medium font-body">
-                        <span class="text-jhublue">Hummingbird</span>
+                        <span class="text-jhublue"><a href="/">Databases</a></span>
                     </h1>
                 </div>
             </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,9 @@
   </head>
   <%= render "layouts/header" %>
    <body>
-    <%= yield %>
+    <section class="mx-16">
+      <%= yield %>
+    </section>
   </body>
   <%= render "layouts/footer" %>
 </html>

--- a/app/views/subheadings/_form.html.erb
+++ b/app/views/subheadings/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: subheading, class: "contents") do |form| %>
+  <% if subheading.errors.any? %>
+    <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
+      <h2><%= pluralize(subheading.errors.count, "error") %> prohibited this subheading from being saved:</h2>
+
+      <ul>
+        <% subheading.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="my-5">
+    <%= form.label :label %>
+    <%= form.text_field :label, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+  </div>
+
+  <div class="inline">
+    <%= form.submit class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+  </div>
+<% end %>

--- a/app/views/subheadings/_subheading.html.erb
+++ b/app/views/subheadings/_subheading.html.erb
@@ -1,0 +1,12 @@
+<div id="<%= dom_id subheading %>">
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Label:</strong>
+    <%= subheading.label %>
+  </p>
+
+  <% if action_name != "show" %>
+    <%= link_to "Show this subheading", subheading, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to 'Edit this subheading', edit_subheading_path(subheading), class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
+    <hr class="mt-6">
+  <% end %>
+</div>

--- a/app/views/subheadings/_subheading.json.jbuilder
+++ b/app/views/subheadings/_subheading.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.extract! subheading, :id, :label, :created_at, :updated_at
+json.url subheading_url(subheading, format: :json)

--- a/app/views/subheadings/edit.html.erb
+++ b/app/views/subheadings/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">Editing subheading</h1>
+
+  <%= render "form", subheading: @subheading %>
+
+  <%= link_to "Show this subheading", @subheading, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%= link_to "Back to subheadings", subheadings_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/app/views/subheadings/index.html.erb
+++ b/app/views/subheadings/index.html.erb
@@ -1,0 +1,14 @@
+<div class="w-full">
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+  <% end %>
+
+  <div class="flex justify-between items-center">
+    <h1 class="font-bold text-4xl">Subheadings</h1>
+    <%= link_to 'New subheading', new_subheading_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
+  </div>
+
+  <div id="subheadings" class="min-w-full">
+    <%= render @subheadings %>
+  </div>
+</div>

--- a/app/views/subheadings/index.json.jbuilder
+++ b/app/views/subheadings/index.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @subheadings, partial: 'subheadings/subheading', as: :subheading

--- a/app/views/subheadings/new.html.erb
+++ b/app/views/subheadings/new.html.erb
@@ -1,0 +1,7 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">New subheading</h1>
+
+  <%= render "form", subheading: @subheading %>
+
+  <%= link_to 'Back to subheadings', subheadings_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/app/views/subheadings/show.html.erb
+++ b/app/views/subheadings/show.html.erb
@@ -1,0 +1,15 @@
+<div class="mx-auto md:w-2/3 w-full flex">
+  <div class="mx-auto">
+    <% if notice.present? %>
+      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+    <% end %>
+
+    <%= render @subheading %>
+
+    <%= link_to 'Edit this subheading', edit_subheading_path(@subheading), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <div class="inline-block ml-2">
+      <%= button_to 'Destroy this subheading', subheading_path(@subheading), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+    </div>
+    <%= link_to 'Back to subheadings', subheadings_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  </div>
+</div>

--- a/app/views/subheadings/show.json.jbuilder
+++ b/app/views/subheadings/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! 'subheadings/subheading', subheading: @subheading

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  resources :database_headings
+  resources :subheadings
+  resources :sub_headings
+  resources :headings
   resources :databases
   resources :vendors
   devise_for :users

--- a/db/migrate/20220602185940_create_headings.rb
+++ b/db/migrate/20220602185940_create_headings.rb
@@ -1,0 +1,9 @@
+class CreateHeadings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :headings do |t|
+      t.string :label
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220602185953_create_subheadings.rb
+++ b/db/migrate/20220602185953_create_subheadings.rb
@@ -1,0 +1,9 @@
+class CreateSubheadings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :subheadings do |t|
+      t.string :label
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220602190058_create_database_headings.rb
+++ b/db/migrate/20220602190058_create_database_headings.rb
@@ -1,0 +1,11 @@
+class CreateDatabaseHeadings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :database_headings do |t|
+      t.string :jhu_id
+      t.references :heading, null: false, foreign_key: true
+      t.references :subheading, null: false, foreign_key: true
+      t.references :database, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220606134641_add_multicolumn_index_to_database_headings.rb
+++ b/db/migrate/20220606134641_add_multicolumn_index_to_database_headings.rb
@@ -1,0 +1,5 @@
+class AddMulticolumnIndexToDatabaseHeadings < ActiveRecord::Migration[7.0]
+  def change
+    add_index :database_headings, [:heading_id, :subheading_id, :jhu_id, :database_id], unique: true, name: 'multicolumn_db_heading_index'
+  end
+end

--- a/db/migrate/20220606135638_add_multicolumn_index_to_database_headings_jhu_id.rb
+++ b/db/migrate/20220606135638_add_multicolumn_index_to_database_headings_jhu_id.rb
@@ -1,0 +1,5 @@
+class AddMulticolumnIndexToDatabaseHeadingsJhuId < ActiveRecord::Migration[7.0]
+  def change
+    add_index :database_headings, [:heading_id, :subheading_id, :jhu_id], unique: true, name: 'multicolumn_jhu_id_index'
+  end
+end

--- a/db/migrate/20220606140026_add_unique_label_index_to_headings.rb
+++ b/db/migrate/20220606140026_add_unique_label_index_to_headings.rb
@@ -1,0 +1,5 @@
+class AddUniqueLabelIndexToHeadings < ActiveRecord::Migration[7.0]
+  def change
+    add_index :headings, :label, unique: true
+  end
+end

--- a/db/migrate/20220606140103_add_unique_label_index_to_subheadings.rb
+++ b/db/migrate/20220606140103_add_unique_label_index_to_subheadings.rb
@@ -1,0 +1,5 @@
+class AddUniqueLabelIndexToSubheadings < ActiveRecord::Migration[7.0]
+  def change
+    add_index :subheadings, :label, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_02_175340) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_06_140103) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "database_headings", force: :cascade do |t|
+    t.string "jhu_id"
+    t.bigint "heading_id", null: false
+    t.bigint "subheading_id", null: false
+    t.bigint "database_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["database_id"], name: "index_database_headings_on_database_id"
+    t.index ["heading_id", "subheading_id", "jhu_id", "database_id"], name: "multicolumn_db_heading_index", unique: true
+    t.index ["heading_id", "subheading_id", "jhu_id"], name: "multicolumn_jhu_id_index", unique: true
+    t.index ["heading_id"], name: "index_database_headings_on_heading_id"
+    t.index ["jhu_id"], name: "index_database_headings_on_jhu_id", unique: true
+    t.index ["subheading_id"], name: "index_database_headings_on_subheading_id"
+  end
 
   create_table "databases", force: :cascade do |t|
     t.bigint "vendor_id", null: false
@@ -28,6 +43,20 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_02_175340) do
     t.index ["name"], name: "index_databases_on_name", unique: true
     t.index ["url"], name: "index_databases_on_url", unique: true
     t.index ["vendor_id"], name: "index_databases_on_vendor_id"
+  end
+
+  create_table "headings", force: :cascade do |t|
+    t.string "label"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["label"], name: "index_headings_on_label", unique: true
+  end
+
+  create_table "subheadings", force: :cascade do |t|
+    t.string "label"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["label"], name: "index_subheadings_on_label", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -50,5 +79,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_02_175340) do
     t.index ["brand_name"], name: "index_vendors_on_brand_name", unique: true
   end
 
+  add_foreign_key "database_headings", "databases"
+  add_foreign_key "database_headings", "headings"
+  add_foreign_key "database_headings", "subheadings"
   add_foreign_key "databases", "vendors"
 end

--- a/spec/factories/database_headings.rb
+++ b/spec/factories/database_headings.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :database_heading do
+    jhu_id { "JHU#{FFaker::Lorem.characters(5)}" }
+    heading { FactoryBot.build(:heading) }
+    subheading { FactoryBot.build(:subheading) }
+    database { FactoryBot.build(:database) }
+  end
+end

--- a/spec/factories/headings.rb
+++ b/spec/factories/headings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :heading do
+    label { FFaker::Education.major }
+  end
+end

--- a/spec/factories/subheadings.rb
+++ b/spec/factories/subheadings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :subheading do
+    label { FFaker::Education.major }
+  end
+end

--- a/spec/requests/database_headings_spec.rb
+++ b/spec/requests/database_headings_spec.rb
@@ -13,12 +13,13 @@ RSpec.describe '/database_headings', type: :request do
     { jhu_id: database.jhu_id, database_id: database.id, heading_id: heading.id, subheading_id: subheading.id }
   end
 
+  let(:updated_attributes) do
+    { jhu_id: "JHU#{FFaker::Lorem.characters(5)}", database_id: database.id, heading_id: heading.id, subheading_id: subheading.id }
+  end
+
   before do
     sign_in user
-    heading.save!
-    subheading.save!
-    database.save!
-    database_heading.save!
+    [database, heading, subheading, database_heading].each(&:save!)
   end
 
   describe 'GET /index' do
@@ -83,13 +84,13 @@ RSpec.describe '/database_headings', type: :request do
   describe 'PATCH /update' do
     context 'with valid parameters' do
       it 'updates the requested database_heading' do
-        patch database_heading_url(database_heading), params: { database_heading: database_heading.attributes }
+        patch database_heading_url(database_heading), params: { database_heading: updated_attributes }
         database_heading.reload
         expect(response).to have_http_status(:found)
       end
 
       it 'redirects to the database_heading' do
-        patch database_heading_url(database_heading), params: { database_heading: database_heading.attributes }
+        patch database_heading_url(database_heading), params: { database_heading: updated_attributes }
         database_heading.reload
         expect(response).to redirect_to(database_heading_url(database_heading))
       end

--- a/spec/requests/database_headings_spec.rb
+++ b/spec/requests/database_headings_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '/database_headings', type: :request do
+  let(:user) { FactoryBot.create(:user) }
+  let(:database_heading) { FactoryBot.create(:database_heading) }
+  let(:heading) { FactoryBot.create(:heading) }
+  let(:subheading) { FactoryBot.create(:subheading) }
+  let(:database) { FactoryBot.create(:database) }
+
+  let(:required_attributes) do
+    { jhu_id: database.jhu_id, database_id: database.id, heading_id: heading.id, subheading_id: subheading.id }
+  end
+
+  before do
+    sign_in user
+    heading.save!
+    subheading.save!
+    database.save!
+    database_heading.save!
+  end
+
+  describe 'GET /index' do
+    it 'renders a successful response' do
+      get database_headings_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /show' do
+    it 'renders a successful response' do
+      get database_heading_url(database_heading)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /new' do
+    it 'renders a successful response' do
+      get new_database_heading_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /edit' do
+    it 'renders a successful response' do
+      get edit_database_heading_url(database_heading)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters' do
+      it 'creates a new DatabaseHeading' do
+        expect do
+          post database_headings_url, params: { database_heading: required_attributes }
+        end.to change(DatabaseHeading, :count).by(1)
+      end
+
+      it 'redirects to the created database_heading' do
+        post database_headings_url, params: { database_heading: required_attributes }
+        expect(response).to redirect_to(database_heading_url(DatabaseHeading.last))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new DatabaseHeading' do
+        allow_any_instance_of(DatabaseHeading).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+
+        put database_heading_url(database_heading), params: { database_heading: { id: '1' } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders a response with 422 status (i.e. to display the 'new' template)" do
+        allow_any_instance_of(DatabaseHeading).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+        post database_headings_url, params: { database_heading: { id: '1' } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'PATCH /update' do
+    context 'with valid parameters' do
+      it 'updates the requested database_heading' do
+        patch database_heading_url(database_heading), params: { database_heading: database_heading.attributes }
+        database_heading.reload
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'redirects to the database_heading' do
+        patch database_heading_url(database_heading), params: { database_heading: database_heading.attributes }
+        database_heading.reload
+        expect(response).to redirect_to(database_heading_url(database_heading))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+        allow_any_instance_of(DatabaseHeading).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+
+        patch database_heading_url(database_heading), params: { database_heading: { id: '1' } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the requested database_heading' do
+      expect do
+        delete database_heading_url(database_heading)
+      end.to change(DatabaseHeading, :count).by(-1)
+    end
+
+    it 'redirects to the categories list' do
+      delete database_heading_url(database_heading)
+      expect(response).to redirect_to(database_headings_url)
+    end
+  end
+end

--- a/spec/requests/headings_spec.rb
+++ b/spec/requests/headings_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '/headings', type: :request do
+  let(:user) { FactoryBot.create(:user) }
+  let(:heading) { FactoryBot.create(:heading) }
+  let(:required_attributes) do
+    { label: heading.label }
+  end
+
+  before do
+    sign_in user
+    heading.save!
+  end
+
+  describe 'GET /index' do
+    it 'renders a successful response' do
+      get headings_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /show' do
+    it 'renders a successful response' do
+      get heading_url(heading)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /new' do
+    it 'renders a successful response' do
+      get new_heading_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /edit' do
+    it 'renders a successful response' do
+      get edit_heading_url(heading)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters' do
+      it 'creates a new Heading' do
+        expect do
+          post headings_url, params: { heading: required_attributes }
+        end.to change(Heading, :count).by(1)
+      end
+
+      it 'redirects to the created heading' do
+        post headings_url, params: { heading: required_attributes }
+        expect(response).to redirect_to(heading_url(Heading.last))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new Heading' do
+        allow_any_instance_of(Heading).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+
+        put heading_url(heading), params: { heading: { id: '1' } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders a response with 422 status (i.e. to display the 'new' template)" do
+        allow_any_instance_of(Heading).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+        post headings_url, params: { heading: { id: '1' } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'PATCH /update' do
+    context 'with valid parameters' do
+      it 'updates the requested heading' do
+        patch heading_url(heading), params: { heading: heading.attributes }
+        heading.reload
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'redirects to the heading' do
+        patch heading_url(heading), params: { heading: heading.attributes }
+        heading.reload
+        expect(response).to redirect_to(heading_url(heading))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+        allow_any_instance_of(Heading).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+
+        patch heading_url(heading), params: { heading: { id: '1' } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the requested heading' do
+      expect do
+        delete heading_url(heading)
+      end.to change(Heading, :count).by(-1)
+    end
+
+    it 'redirects to the categories list' do
+      delete heading_url(heading)
+      expect(response).to redirect_to(headings_url)
+    end
+  end
+end

--- a/spec/requests/headings_spec.rb
+++ b/spec/requests/headings_spec.rb
@@ -46,12 +46,12 @@ RSpec.describe '/headings', type: :request do
     context 'with valid parameters' do
       it 'creates a new Heading' do
         expect do
-          post headings_url, params: { heading: required_attributes }
+          post headings_url, params: { heading: { label: FFaker::Education.major } }
         end.to change(Heading, :count).by(1)
       end
 
       it 'redirects to the created heading' do
-        post headings_url, params: { heading: required_attributes }
+        post headings_url, params: { heading: { label: FFaker::Education.major } }
         expect(response).to redirect_to(heading_url(Heading.last))
       end
     end

--- a/spec/requests/subheadings_spec.rb
+++ b/spec/requests/subheadings_spec.rb
@@ -46,12 +46,12 @@ RSpec.describe '/subheadings', type: :request do
     context 'with valid parameters' do
       it 'creates a new Subheading' do
         expect do
-          post subheadings_url, params: { subheading: required_attributes }
+          post subheadings_url, params: { subheading: { label: FFaker::Education.major } }
         end.to change(Subheading, :count).by(1)
       end
 
       it 'redirects to the created subheading' do
-        post subheadings_url, params: { subheading: required_attributes }
+        post subheadings_url, params: { subheading: { label: FFaker::Education.major } }
         expect(response).to redirect_to(subheading_url(Subheading.last))
       end
     end
@@ -76,13 +76,13 @@ RSpec.describe '/subheadings', type: :request do
   describe 'PATCH /update' do
     context 'with valid parameters' do
       it 'updates the requested subheading' do
-        patch subheading_url(subheading), params: { subheading: subheading.attributes }
+        patch subheading_url(subheading), params: { subheading: { label: FFaker::Education.major } }
         subheading.reload
         expect(response).to have_http_status(:found)
       end
 
       it 'redirects to the subheading' do
-        patch subheading_url(subheading), params: { subheading: subheading.attributes }
+        patch subheading_url(subheading), params: { subheading: { label: FFaker::Education.major } }
         subheading.reload
         expect(response).to redirect_to(subheading_url(subheading))
       end

--- a/spec/requests/subheadings_spec.rb
+++ b/spec/requests/subheadings_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '/subheadings', type: :request do
+  let(:user) { FactoryBot.create(:user) }
+  let(:subheading) { FactoryBot.create(:subheading) }
+  let(:required_attributes) do
+    { label: subheading.label }
+  end
+
+  before do
+    sign_in user
+    subheading.save!
+  end
+
+  describe 'GET /index' do
+    it 'renders a successful response' do
+      get subheadings_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /show' do
+    it 'renders a successful response' do
+      get subheading_url(subheading)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /new' do
+    it 'renders a successful response' do
+      get new_subheading_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /edit' do
+    it 'renders a successful response' do
+      get edit_subheading_url(subheading)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters' do
+      it 'creates a new Subheading' do
+        expect do
+          post subheadings_url, params: { subheading: required_attributes }
+        end.to change(Subheading, :count).by(1)
+      end
+
+      it 'redirects to the created subheading' do
+        post subheadings_url, params: { subheading: required_attributes }
+        expect(response).to redirect_to(subheading_url(Subheading.last))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new Subheading' do
+        allow_any_instance_of(Subheading).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+
+        put subheading_url(subheading), params: { subheading: { id: '1' } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders a response with 422 status (i.e. to display the 'new' template)" do
+        allow_any_instance_of(Subheading).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+        post subheadings_url, params: { subheading: { id: '1' } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'PATCH /update' do
+    context 'with valid parameters' do
+      it 'updates the requested subheading' do
+        patch subheading_url(subheading), params: { subheading: subheading.attributes }
+        subheading.reload
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'redirects to the subheading' do
+        patch subheading_url(subheading), params: { subheading: subheading.attributes }
+        subheading.reload
+        expect(response).to redirect_to(subheading_url(subheading))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+        allow_any_instance_of(Subheading).to receive(:save).and_return(false) # rubocop:disable RSpec/AnyInstance
+
+        patch subheading_url(subheading), params: { subheading: { id: '1' } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the requested subheading' do
+      expect do
+        delete subheading_url(subheading)
+      end.to change(Subheading, :count).by(-1)
+    end
+
+    it 'redirects to the categories list' do
+      delete subheading_url(subheading)
+      expect(response).to redirect_to(subheadings_url)
+    end
+  end
+end

--- a/spec/system/database_headings_spec.rb
+++ b/spec/system/database_headings_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Heading-related CRUD Operations', type: :system do
+  let(:user) { FactoryBot.create(:user) }
+  let(:vendor) { FactoryBot.create(:vendor) }
+  let(:database) { FactoryBot.create(:database) }
+  let(:heading) { FactoryBot.create(:heading) }
+  let(:subheading) { FactoryBot.create(:subheading) }
+  let(:database_heading) { FactoryBot.create(:database_heading) }
+
+  before do
+    driven_by(:selenium_chrome_headless)
+    visit root_path
+
+    vendor.save!
+
+    click_link 'Log in'
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+    click_button 'Log in'
+  end
+
+  it 'can create a heading' do
+    visit '/headings'
+
+    click_on 'New heading'
+    fill_in 'Label', with: FFaker::Education.major
+
+    click_on 'Create Heading'
+
+    expect(page).to have_content('Heading was successfully created.')
+  end
+
+  it 'can create a subheading' do
+    visit '/subheadings'
+
+    click_on 'New subheading'
+    fill_in 'Label', with: FFaker::Education.major
+
+    click_on 'Create Subheading'
+
+    expect(page).to have_content('Subheading was successfully created.')
+  end
+
+  it 'can create a database heading' do
+    heading.save!
+    subheading.save!
+    database.save!
+
+    visit '/database_headings'
+
+    click_on 'New database heading'
+    click_on 'Create Database heading'
+    expect(page).to have_content('Database heading was successfully created.')
+  end
+
+  it 'can update a database heading' do
+    heading.save!
+    subheading.save!
+    database.save!
+    database_heading.save!
+    visit '/database_headings'
+
+    click_on 'Edit this database heading'
+    click_on 'Update Database heading'
+    expect(page).to have_content('Database heading was successfully updated.')
+  end
+
+  it 'can delete a database heading' do
+    heading.save!
+    subheading.save!
+    database.save!
+    database_heading.save!
+    visit '/database_headings'
+
+    click_on 'Show this database heading'
+    click_on 'Destroy this database_heading'
+
+    expect(page).to have_content('Database heading was successfully destroyed.')
+  end
+end

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe 'HomePages', type: :system do
 
   it 'is accessible' do
     visit root_path
-    expect(page).to have_content('Hummingbird')
+    expect(page).to have_content('Databases')
   end
 end


### PR DESCRIPTION
This adds CRUD for Headings.

This PR has additional database migrations. After
checking out this branch you'll need to run
docker-compose run --rm hummingbird bundle exec rake db:migrate
to update the database.

You can test the functionality by logging in and visiting
/headings/, /subheadigns and /database_headings.

You'll need to create a heading and a subheading. After that
you'll be able to create a database_heading, which associates
a heading with a database.

These are the most basic forms for this functionality. We'll
need to combine some of the forms so that you don't need to
visit the /database_headings forms to add a heading to a database.