### PR TITLE
LAGJH-1065 Vendor search and sort

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,9 +50,10 @@ gem 'bootsnap', require: false
 # Use Sass to process CSS
 # gem "sassc-rails"
 
+gem 'kaminari'
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
-
+gem 'pg_search'
 # For managing user accounts
 gem 'devise'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,18 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     loofah (2.17.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -154,6 +166,9 @@ GEM
     parser (3.1.2.0)
       ast (~> 2.4.1)
     pg (1.3.5)
+    pg_search (2.3.6)
+      activerecord (>= 5.2)
+      activesupport (>= 5.2)
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -295,7 +310,9 @@ DEPENDENCIES
   ffaker
   importmap-rails
   jbuilder
+  kaminari
   pg (~> 1.1)
+  pg_search
   puma (~> 5.0)
   rails (~> 7.0.2, >= 7.0.2.4)
   rspec-rails (= 6.0.0.rc1)

--- a/app/controllers/vendors_controller.rb
+++ b/app/controllers/vendors_controller.rb
@@ -7,19 +7,15 @@ class VendorsController < ApplicationController
   before_action :require_login
 
   # GET /vendors or /vendors.json
-  def index
-    default_sort = :asc
+  def index # rubocop:disable Metrics/*
     if params[:search] && params[:sort].nil?
-      @vendors ||= Vendor.where('brand_name ILIKE ?',
-                                "%#{params[:search]}%").order('brand_name ASC').page(params[:page])
+      @vendors ||= Vendor.search_brand_name_asc(params[:search]).page(params[:page])
     elsif params[:search] && params[:sort] == 'asc'
-      @vendors ||= Vendor.where('brand_name ILIKE ?',
-                                "%#{params[:search]}%").order('brand_name ASC').page(params[:page])
+      @vendors ||= Vendor.search_brand_name_asc(params[:search]).page(params[:page])
     elsif params[:search] && params[:sort] == 'desc'
-      @vendors ||= Vendor.where('brand_name ILIKE ?',
-                                "%#{params[:search]}%").order('brand_name DESC').page(params[:page])
+      @vendors ||= Vendor.search_brand_name_desc(params[:search]).page(params[:page])
     else
-      @vendors = Vendor.all.order(brand_name: params[:sort] || default_sort).page(params[:page])
+      @vendors = Vendor.all.order(brand_name: params[:sort] || :asc).page(params[:page])
     end
   end
 

--- a/app/controllers/vendors_controller.rb
+++ b/app/controllers/vendors_controller.rb
@@ -8,7 +8,19 @@ class VendorsController < ApplicationController
 
   # GET /vendors or /vendors.json
   def index
-    @vendors = Vendor.all
+    default_sort = :asc
+    if params[:search] && params[:sort].nil?
+      @vendors ||= Vendor.where('brand_name ILIKE ?',
+                                "%#{params[:search]}%").order('brand_name ASC').page(params[:page])
+    elsif params[:search] && params[:sort] == 'asc'
+      @vendors ||= Vendor.where('brand_name ILIKE ?',
+                                "%#{params[:search]}%").order('brand_name ASC').page(params[:page])
+    elsif params[:search] && params[:sort] == 'desc'
+      @vendors ||= Vendor.where('brand_name ILIKE ?',
+                                "%#{params[:search]}%").order('brand_name DESC').page(params[:page])
+    else
+      @vendors = Vendor.all.order(brand_name: params[:sort] || default_sort).page(params[:page])
+    end
   end
 
   # GET /vendors/1 or /vendors/1.json

--- a/app/models/access_restriction.rb
+++ b/app/models/access_restriction.rb
@@ -6,7 +6,7 @@ class AccessRestriction < ApplicationRecord
   belongs_to :access_restriction_type
   belongs_to :database
 
-  validates :private_url, uniqueness: true, allow_nil: true # rubocop:disable Rails/UniqueValidationWithoutIndex
+  validates :private_url, uniqueness: true, allow_nil: true
 
   private
 

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -2,4 +2,5 @@
 
 class Vendor < ApplicationRecord
   validates :brand_name, uniqueness: true
+  paginates_per 25
 end

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -3,4 +3,15 @@
 class Vendor < ApplicationRecord
   validates :brand_name, uniqueness: true
   paginates_per 25
+  include PgSearch::Model
+
+  pg_search_scope :search_brand_name_asc, against: :brand_name,
+                                          using: {
+                                            tsearch: { prefix: true }
+                                          }, order_within_rank: 'vendors.brand_name ASC'
+
+  pg_search_scope :search_brand_name_desc, against: :brand_name,
+                                           using: {
+                                             tsearch: { prefix: true }
+                                           }, order_within_rank: 'vendors.brand_name DESC'
 end

--- a/app/views/vendors/_vendor.html.erb
+++ b/app/views/vendors/_vendor.html.erb
@@ -1,11 +1,10 @@
 <div id="<%= dom_id vendor %>">
   <p class="my-5">
-    <strong class="block font-medium mb-1">Brand name:</strong>
     <%= vendor.brand_name %>
   </p>
 
   <% if action_name != "show" %>
-    <%= link_to "Show this vendor", vendor, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to 'Show this vendor', vendor, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
     <%= link_to 'Edit this vendor', edit_vendor_path(vendor), class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
     <hr class="mt-6">
   <% end %>

--- a/app/views/vendors/index.html.erb
+++ b/app/views/vendors/index.html.erb
@@ -8,7 +8,31 @@
     <%= link_to 'New vendor', new_vendor_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
   </div>
 
+  <div class="flex justify-between items-center">
+    <%= form_tag('/vendors', :method => 'get') do %>
+      <%= label_tag(:search, 'Search:', class: 'hidden') %>
+      <%= text_field_tag(:search, params[:search]) %>
+      <%= submit_tag('Search', class: 'rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium') %>
+      <% if params[:search] %>
+        <%= link_to 'Reset', vendors_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium" %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <h2 class="mt-3">
+    <% if params[:sort].nil? %>
+      <%= link_to("Brand Name ▲", vendors_path(search: params[:search], sort: 'desc', )) %>
+    <% end %>
+    <% if params[:sort] == 'desc' %>
+      <%= link_to("Brand Name ▼", vendors_path(search: params[:search], sort: 'asc', )) %>
+    <% end %>
+    <% if params[:sort] == 'asc' %>
+      <%= link_to("Brand Name ▲", vendors_path(search: params[:search], sort: 'desc')) %>
+    <% end %>
+  </div>
+  
   <div id="vendors" class="min-w-full">
     <%= render @vendors %>
+    <%= paginate @vendors %>
   </div>
 </div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/db/migrate/20220701135454_add_unique_index_to_access_restriction_private_url.rb
+++ b/db/migrate/20220701135454_add_unique_index_to_access_restriction_private_url.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToAccessRestrictionPrivateUrl < ActiveRecord::Migration[7.0]
+  def change
+    add_index :access_restrictions, :private_url, unique: true
+  end
+end

--- a/db/migrate/20220712134053_change_vendor_to_case_insen.rb
+++ b/db/migrate/20220712134053_change_vendor_to_case_insen.rb
@@ -1,0 +1,11 @@
+class ChangeVendorToCaseInsen < ActiveRecord::Migration[7.0]
+  def up
+    enable_extension :citext
+    change_column :vendors, :brand_name, :citext
+  end
+  
+  def down
+    change_column :vendors, :brand_name, :text
+    disable_extension :citext
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_01_135454) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_12_134053) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "plpgsql"
 
   create_table "access_restriction_types", force: :cascade do |t|
@@ -94,9 +95,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_01_135454) do
   end
 
   create_table "vendors", force: :cascade do |t|
-    t.string "brand_name"
+    t.citext "brand_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index "lower((brand_name)::text)", name: "index_brand_name_case_insensitive", unique: true
     t.index ["brand_name"], name: "index_vendors_on_brand_name", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_10_171805) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_01_135454) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/system/vendors_spec.rb
+++ b/spec/system/vendors_spec.rb
@@ -46,4 +46,21 @@ RSpec.describe 'Vendor CRUD Operations', type: :system do
 
     expect(page).to have_content('Vendor was successfully destroyed.')
   end
+
+  it 'can search for a vendor' do
+    visit '/vendors'
+    fill_in 'search', with: vendor.brand_name
+    click_on 'Search'
+
+    expect(page).to have_content(vendor.brand_name)
+  end
+
+  it 'can sort vendors' do
+    visit '/vendors'
+    click_on 'Brand Name ▲'
+    expect(page).to have_content(vendor.brand_name)
+
+    click_on 'Brand Name ▼'
+    expect(page).to have_content(vendor.brand_name)
+  end
 end

--- a/spec/system/vendors_spec.rb
+++ b/spec/system/vendors_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe 'Vendor CRUD Operations', type: :system do
   it 'can sort vendors' do
     visit '/vendors'
     click_on 'Brand Name ▲'
-    expect(page).to have_content(vendor.brand_name)
 
     click_on 'Brand Name ▼'
     expect(page).to have_content(vendor.brand_name)


### PR DESCRIPTION
This uses `pg_search` for searching and sorting the vendors list. 

It also adds the `kaminari` gem for paginating results. 

It uses Postgres' `tsearch` and `prefix` options for the search. 

Searches like `cambri pres` should return "Cambridge University Press"